### PR TITLE
Examples Docstring

### DIFF
--- a/configuration_management/napalm_install_config
+++ b/configuration_management/napalm_install_config
@@ -85,10 +85,10 @@ options:
 
 EXAMPLES = '''
 - name: Assemble configuration
-assemble: src=../compiled/{{ inventory_hostname }}/ dest=../compiled/{{ inventory_hostname }}/running.conf
+  assemble: src=../compiled/{{ inventory_hostname }}/ dest=../compiled/{{ inventory_hostname }}/running.conf
 
 - name: Push Configuration
-napalm_install_config:
+  napalm_install_config:
     hostname={{ inventory_hostname }}
     username=dbarroso
     dev_os={{os}}

--- a/configuration_management/napalm_install_config
+++ b/configuration_management/napalm_install_config
@@ -90,6 +90,7 @@ EXAMPLES = '''
     username=dbarroso
     dev_os={{os}}
     password=p4ssw0rd
+    config_file=../compiled/{{ inventory_hostname }}/running.conf
 '''
 
 

--- a/configuration_management/napalm_install_config
+++ b/configuration_management/napalm_install_config
@@ -85,10 +85,6 @@ options:
 
 EXAMPLES = '''
 
-- assemble:
-    src=../compiled/{{ inventory_hostname }}/
-    dest=../compiled/{{ inventory_hostname }}/running.conf
-
 - napalm_install_config:
     hostname={{ inventory_hostname }}
     username=dbarroso

--- a/configuration_management/napalm_install_config
+++ b/configuration_management/napalm_install_config
@@ -91,6 +91,9 @@ EXAMPLES = '''
     dev_os={{os}}
     password=p4ssw0rd
     config_file=../compiled/{{ inventory_hostname }}/running.conf
+    commit_changes={{ commit_changes }}
+    replace_config={{ replace_config }}
+    diff_file=../compiled/{{ inventory_hostname }}/diff
 '''
 
 

--- a/configuration_management/napalm_install_config
+++ b/configuration_management/napalm_install_config
@@ -84,32 +84,19 @@ options:
 '''
 
 EXAMPLES = '''
-    In our playbook would have something like:
+- name: Assemble configuration
+assemble: src=../compiled/{{ inventory_hostname }}/ dest=../compiled/{{ inventory_hostname }}/running.conf
 
-  tasks:
-  - name: Assemble configuration
-    assemble: src=../compiled/{{ inventory_hostname }}/ dest=../compiled/{{ inventory_hostname }}/running.conf
-  - name: Push Configuration
-    napalm_install_config:
-        hostname={{ inventory_hostname }}
-        username=dbarroso
-        dev_os={{os}}
-        password=p4ssw0rd
-        config_file=../compiled/{{ inventory_hostname }}/running.conf
-        commit_changes={{ commit_changes }}
-        replace_config={{ replace_config }}
-        diff_file=../compiled/{{ inventory_hostname }}/diff
-        timeout={{timeout}}
-
-    From the CLI we would trigger the playbook like:
-
-        # We don't commit changes, we only want to check the diff
-        $ ansible-playbook -v -e commit_changes=0 napalm_test.yml
-
-        or
-
-        # We actually commit the changes
-        $ ansible-playbook -v -e commit_changes=1 napalm_test.yml
+- name: Push Configuration
+napalm_install_config:
+    hostname={{ inventory_hostname }}
+    username=dbarroso
+    dev_os={{os}}
+    password=p4ssw0rd
+    config_file=../compiled/{{ inventory_hostname }}/running.conf
+    commit_changes={{ commit_changes }}
+    replace_config={{ replace_config }}
+    diff_file=../compiled/{{ inventory_hostname }}/diff
 '''
 
 

--- a/configuration_management/napalm_install_config
+++ b/configuration_management/napalm_install_config
@@ -85,6 +85,10 @@ options:
 
 EXAMPLES = '''
 
+- assemble:
+    src=../compiled/{{ inventory_hostname }}/
+    dest=../compiled/{{ inventory_hostname }}/running.conf
+
 - napalm_install_config:
     hostname={{ inventory_hostname }}
     username=dbarroso

--- a/configuration_management/napalm_install_config
+++ b/configuration_management/napalm_install_config
@@ -87,13 +87,6 @@ EXAMPLES = '''
 
 - napalm_install_config:
     hostname={{ inventory_hostname }}
-    username=dbarroso
-    dev_os={{os}}
-    password=p4ssw0rd
-    config_file=../compiled/{{ inventory_hostname }}/running.conf
-    commit_changes={{ commit_changes }}
-    replace_config={{ replace_config }}
-    diff_file=../compiled/{{ inventory_hostname }}/diff
 '''
 
 

--- a/configuration_management/napalm_install_config
+++ b/configuration_management/napalm_install_config
@@ -87,6 +87,9 @@ EXAMPLES = '''
 
 - napalm_install_config:
     hostname={{ inventory_hostname }}
+    username=dbarroso
+    dev_os={{os}}
+    password=p4ssw0rd
 '''
 
 

--- a/configuration_management/napalm_install_config
+++ b/configuration_management/napalm_install_config
@@ -84,7 +84,10 @@ options:
 '''
 
 EXAMPLES = '''
-- assemble: src=../compiled/{{ inventory_hostname }}/ dest=../compiled/{{ inventory_hostname }}/running.conf
+
+- assemble:
+    src=../compiled/{{ inventory_hostname }}/
+    dest=../compiled/{{ inventory_hostname }}/running.conf
 
 - napalm_install_config:
     hostname={{ inventory_hostname }}

--- a/configuration_management/napalm_install_config
+++ b/configuration_management/napalm_install_config
@@ -84,11 +84,9 @@ options:
 '''
 
 EXAMPLES = '''
-- name: Assemble configuration
-  assemble: src=../compiled/{{ inventory_hostname }}/ dest=../compiled/{{ inventory_hostname }}/running.conf
+- assemble: src=../compiled/{{ inventory_hostname }}/ dest=../compiled/{{ inventory_hostname }}/running.conf
 
-- name: Push Configuration
-  napalm_install_config:
+- napalm_install_config:
     hostname={{ inventory_hostname }}
     username=dbarroso
     dev_os={{os}}


### PR DESCRIPTION
I was trying to build some webdocs for these modules, and my module formatter didn't like the examples section. The way it is now is more in line with official Ansible guidelines.

http://docs.ansible.com/ansible/developing_modules.html
