### PR TITLE
Adding optional_args support

### DIFF
--- a/configuration_management/napalm_install_config
+++ b/configuration_management/napalm_install_config
@@ -81,6 +81,10 @@ options:
               even if the diff_file param is not set.
         choices: [yes,on,1,true,no,off,0,false]
         required: False
+    optional_args:
+        description:
+          - Dictionary of additional arguments passed to underlying driver
+        required: false
 '''
 
 EXAMPLES = '''
@@ -120,10 +124,16 @@ def main():
                                 default=False),
             diff_file=dict(required=False, default=None),
             get_diffs=dict(required=False, choices=BOOLEANS, type='bool',
-                           default=True)
+                           default=True),
+            optional_args=dict(required=False, type='dict', default=None),
         ),
         supports_check_mode=True
     )
+
+    if module.params['optional_args'] is None:
+        optional_args = {}
+    else:
+        optional_args = module.params['optional_args']
 
     hostname = module.params['hostname']
     username = module.params['username']
@@ -139,7 +149,7 @@ def main():
 
     network_driver = get_network_driver(dev_os)
 
-    device = network_driver(hostname, username, password, timeout)
+    device = network_driver(hostname, username, password, timeout, optional_args=optional_args)
     device.open()
 
     if replace_config:

--- a/data_gathering/napalm_get_facts
+++ b/data_gathering/napalm_get_facts
@@ -47,6 +47,10 @@ options:
         description:
           - Password
         required: true
+    optional_args:
+        description:
+          - Dictionary of additional arguments passed to underlying driver
+        required: false
 '''
 
 EXAMPLES = '''
@@ -65,9 +69,15 @@ def main():
             username=dict(required=True),
             password=dict(required=True),
             dev_os=dict(required=True),
+            optional_args=dict(required=False, type='dict', default=None),
         ),
         supports_check_mode=False
     )
+
+    if module.params['optional_args'] is None:
+        optional_args = {}
+    else:
+        optional_args = module.params['optional_args']
 
     hostname = module.params['hostname']
     username = module.params['username']
@@ -76,7 +86,7 @@ def main():
 
     network_driver = get_network_driver(dev_os)
 
-    device = network_driver(hostname, username, password)
+    device = network_driver(hostname, username, password, optional_args=optional_args)
     device.open()
 
     facts = device.get_facts()


### PR DESCRIPTION
Add support into napalm-ansible modules for passing optional arguments (non-standard API/SSH port, non-standard file-system on IOS).

I tested both napalm_install_config and napalm_get_facts, but only on IOS (using a non-standard SSH port).
