### PR TITLE
Change supports_check_mode to True

### DIFF
--- a/library/napalm_get_facts.py
+++ b/library/napalm_get_facts.py
@@ -84,7 +84,7 @@ def main():
             timeout=dict(type='int', required=False, default=60),
             optional_args=dict(required=False, type='dict', default=None),
         ),
-        supports_check_mode=False
+        supports_check_mode=True
     )
 
     if not napalm_found:


### PR DESCRIPTION
Usecase:
When napalm_get_facts is used in the same playbook as napalm_install_config, and the playbook is called with --check (to not push the changes), napalm_get_facts refuses to work.

skipping: [device] => {"changed": false, "invocation": {"module_args": {"_ansible_check_mode": true, "dev_os": "ios", "hostname": "device", "password": "secret", "username": "xionox"}, "module_name": "napalm_get_facts"}, "msg": "remote module does not support check mode", "skipped": true}
