### PR TITLE
Don't create empty diff file if no diff is returned

### DIFF
--- a/library/napalm_install_config.py
+++ b/library/napalm_install_config.py
@@ -200,7 +200,7 @@ def main():
         else:
             changed = True
             diff = None
-        if diff_file is not None and get_diffs:
+        if diff_file is not None and get_diffs and changed:
             save_to_file(diff, diff_file)
     except Exception, e:
         module.fail_json(msg="cannot diff config: " + str(e))


### PR DESCRIPTION
Tested on IOS and PANOS

Currently, when get_diffs is set but there are no diff between the running configuration and the one sent by Napalm, napalm-ansible still generates an empty file.

As the "changed" value is set to true when the content of diff returned, is not null, this patch verifies that something has changed before writing the diff file.
