### PR TITLE
add interfaces_ip to filter description

### DIFF
--- a/library/napalm_get_facts.py
+++ b/library/napalm_get_facts.py
@@ -62,8 +62,8 @@ options:
         description:
             - A list of facts to retreive from a device and provided though C(ansible_facts)
               The following facts are available-
-              facts, environment, interfaces, interfaces_counter, bgp_config, bgp_neighbors,
-              bgp_neighbors_detail, lldp_neighbors, lldp_neighbors_detail
+              facts, environment, interfaces, interfaces_counter, interfaces_ip, bgp_config,
+              bgp_neighbors, bgp_neighbors_detail, lldp_neighbors, lldp_neighbors_detail
               Note- not all getters are implemented on all supported devcie types
         required: False
         default: ['facts']


### PR DESCRIPTION
interfaces_ip was not included in the filter description documentation.