### PR TITLE
Add Provider

### DIFF
--- a/library/napalm_get_facts.py
+++ b/library/napalm_get_facts.py
@@ -34,20 +34,28 @@ options:
     hostname:
         description:
           - IP or FQDN of the device you want to connect to
-        required: True
+        required: False
     username:
         description:
           - Username
-        required: True
+        required: False
     password:
         description:
           - Password
-        required: True
+        required: False
     dev_os:
         description:
           - OS of the device
         required: True
         choices: ['eos', 'junos', 'iosxr', 'fortios', 'ibm', 'ios', 'nxos', 'panos']
+    provider:
+        description
+          - Dictionary which acts as a collection of arguments used to define the characteristics 
+            of how to connect to the device.
+            Note - hostname, username, password and dev_os must be defined in either provider 
+            or local param
+            Note - local param takes precedence, e.g. hostname is preferred to provider['hostname']
+        required: False
     timeout:
         description:
           - Time in seconds to wait for the device to respond
@@ -77,6 +85,14 @@ options:
 '''
 
 EXAMPLES = '''
+
+vars:
+  ios_provider:
+    hostname: "{{ inventory_hostname }}"
+    username: "napalm"
+    password: "napalm"
+    dev_os: "ios"
+
  - name: get facts from device
    napalm_get_facts:
      hostname={{ inventory_hostname }}
@@ -88,6 +104,14 @@ EXAMPLES = '''
 
  - name: print data
    debug: var=result
+
+ - name: Getters
+   napalm_get_facts:
+     provider: "{{ ios_provider }}"
+     filter:
+       - "lldp_neighbors_detail"
+       - "interfaces"
+
 '''
 
 RETURN = '''

--- a/library/napalm_get_facts.py
+++ b/library/napalm_get_facts.py
@@ -133,15 +133,24 @@ def main():
 
     provider = module.params['provider'] or {}
 
+    # allow host or hostname
+    if provider.get('host') and not provider.get('hostname'):
+        provider['hostname'] = provider.get('host')
     # allow local params to override provider
-    hostname = module.params.get('hostname') or provider.get('hostname') or provider.get('host')
-    username = module.params.get('username') or provider.get('username')
-    dev_os = module.params.get('dev_os') or provider.get('dev_os')
-    password = module.params.get('password') or provider.get('password')
-    timeout = module.params.get('timeout') or provider.get('timeout')
+    for param, pvalue in provider.items():
+        value = module.params.get(param)
+        if not value:
+            module.params[param] = pvalue
+
+    hostname = module.params['hostname']
+    username = module.params['username']
+    dev_os = module.params['dev_os']
+    password = module.params['password']
+    timeout = module.params['timeout']
     filter_list = module.params['filter']
     ignore_notimplemented = module.params['ignore_notimplemented']
     implementation_errors = []
+
 
     argument_check = { 'hostname': hostname, 'username': username, 'dev_os': dev_os, 'password': password }
     for key, val in argument_check.items():

--- a/library/napalm_get_facts.py
+++ b/library/napalm_get_facts.py
@@ -114,7 +114,7 @@ def main():
     os_choices = ['eos', 'junos', 'iosxr', 'fortios', 'ibm', 'ios', 'nxos', 'panos']
     module = AnsibleModule(
         argument_spec=dict(
-            hostname=dict(type='str', required=False),
+            hostname=dict(type='str', required=False, aliases=['host']),
             username=dict(type='str', required=False),
             password=dict(type='str', required=False, no_log=True),
             provider=dict(type='dict', required=False, no_log=True),


### PR DESCRIPTION
Added provider similar to that used in other networking modules. 

Note the following: 
- Local params are preferred over provider defined params
- Can use either hostname or host, I added host since that is used in other network modules, but hostname is preferred. 
- Will do the same for napalm_install_config once this PR is deemed good. 

pinging @jedelman8 