### PR TITLE
Fix Docstring to work with read the docs

### DIFF
--- a/library/napalm_get_facts.py
+++ b/library/napalm_get_facts.py
@@ -49,7 +49,7 @@ options:
         required: False
         choices: ['eos', 'junos', 'iosxr', 'fortios', 'ibm', 'ios', 'nxos', 'panos', 'vyos']
     provider:
-        description
+        description:
           - Dictionary which acts as a collection of arguments used to define the characteristics
             of how to connect to the device.
             Note - hostname, username, password and dev_os must be defined in either provider

--- a/library/napalm_install_config.py
+++ b/library/napalm_install_config.py
@@ -46,7 +46,7 @@ options:
           - Password
         required: False
     provider:
-        description
+        description:
           - Dictionary which acts as a collection of arguments used to define the characteristics 
             of how to connect to the device.
             Note - hostname, username, password and dev_os must be defined in either provider 

--- a/library/napalm_validate.py
+++ b/library/napalm_validate.py
@@ -30,7 +30,7 @@ options:
         required: False
         choices: ['eos', 'junos', 'iosxr', 'fortios', 'ibm', 'ios', 'nxos', 'panos', 'vyos']
     provider:
-        description
+        description:
           - Dictionary which acts as a collection of arguments used to define the characteristics 
             of how to connect to the device.
             Note - hostname, username, password and dev_os must be defined in either provider 


### PR DESCRIPTION
Apparently you need a colon after description for doc string to work with read the docs :) 