### PR TITLE
fix provider for local False

### DIFF
--- a/library/napalm_get_facts.py
+++ b/library/napalm_get_facts.py
@@ -159,7 +159,8 @@ def main():
     provider['hostname'] = provider.get('hostname', None) or provider.get('host', None)
     # allow local params to override provider
     for param, pvalue in provider.items():
-        module.params[param] = module.params.get(param, None) or pvalue
+        if module.params.get(param) != False:
+            module.params[param] = module.params.get(param) or pvalue
 
     hostname = module.params['hostname']
     username = module.params['username']

--- a/library/napalm_install_config.py
+++ b/library/napalm_install_config.py
@@ -192,7 +192,8 @@ def main():
     provider['hostname'] = provider.get('hostname', None) or provider.get('host', None)
     # allow local params to override provider
     for param, pvalue in provider.items():
-        module.params[param] = module.params.get(param, None) or pvalue
+        if module.params.get(param) != False:
+            module.params[param] = module.params.get(param) or pvalue
 
     hostname = module.params['hostname']
     username = module.params['username']

--- a/library/napalm_validate.py
+++ b/library/napalm_validate.py
@@ -110,7 +110,8 @@ def get_device_instance(module, os_choices):
     provider['hostname'] = provider.get('hostname', None) or provider.get('host', None)
     # allow local params to override provider
     for param, pvalue in provider.items():
-        module.params[param] = module.params.get(param, None) or pvalue
+        if module.params.get(param) != False:
+            module.params[param] = module.params.get(param) or pvalue
 
     hostname = module.params['hostname']
     username = module.params['username']


### PR DESCRIPTION
In theory this should work, as it seems to in native python:

```
     for param, pvalue in provider.items():
           module.params[param] = module.params.get(param, pvalue) 
```
However, it seems as if ansible is doing some magic and doesn't work at all, so this is a work around. 

Welcome to other suggestions for fixing this use case. 