### PR TITLE
Add action to populate provider

### DIFF
--- a/action_plugins/napalm.py
+++ b/action_plugins/napalm.py
@@ -1,0 +1,26 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import re
+import time
+import glob
+
+from ansible.plugins.action.normal import ActionModule as _ActionModule
+from pprint import pprint
+
+class ActionModule(_ActionModule):
+    def run(self, tmp=None, task_vars=None):
+        pc = self._play_context
+
+        provider = self._task.args.get('provider', {})
+
+        provider['hostname'] = provider.get('hostname', provider.get('host', pc.remote_addr))
+        provider['username'] = provider.get('username', pc.connection_user)
+        provider['password'] = provider.get('password', pc.password)
+        provider['timeout'] = provider.get('timeout', pc.timeout)
+
+        self._task.args['provider'] = provider
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        return result

--- a/action_plugins/napalm_get_facts.py
+++ b/action_plugins/napalm_get_facts.py
@@ -1,0 +1,1 @@
+napalm.py

--- a/action_plugins/napalm_install_config.py
+++ b/action_plugins/napalm_install_config.py
@@ -1,0 +1,1 @@
+napalm.py

--- a/action_plugins/napalm_parse_yang.py
+++ b/action_plugins/napalm_parse_yang.py
@@ -1,0 +1,1 @@
+napalm.py

--- a/action_plugins/napalm_ping.yml
+++ b/action_plugins/napalm_ping.yml
@@ -1,0 +1,1 @@
+napalm.py

--- a/action_plugins/napalm_validate.yml
+++ b/action_plugins/napalm_validate.yml
@@ -1,0 +1,1 @@
+napalm.py


### PR DESCRIPTION
Since ansible 2.3, it is possible with the network action plugins to use the same authentication credentials as with the "systems" modules.
This PR intends to mimic this behaviour in napalm-ansible.

The action is called before the module and populate ```hostname```, ```username``` and ```password``` in the argument ```provider``` if not present.
The values passed as task arguments either by name or in provider keep precedence over these values.