### PR TITLE
If no` arg` is passed default correctly to `{}`

### DIFF
--- a/library/napalm_get_facts.py
+++ b/library/napalm_get_facts.py
@@ -188,7 +188,7 @@ def main():
     password = module.params['password']
     timeout = module.params['timeout']
     filter_list = module.params['filter']
-    args = module.params.get('args', {})
+    args = module.params['args'] or {}
     ignore_notimplemented = module.params['ignore_notimplemented']
     implementation_errors = []
 


### PR DESCRIPTION
Fixes #62 

@ipsapce would you mind testing?

Thanks!