### PR TITLE
Removed exception when SSH connection closes abnormally

### DIFF
--- a/napalm_ansible/napalm_get_facts.py
+++ b/napalm_ansible/napalm_get_facts.py
@@ -267,7 +267,7 @@ def main():
     try:
         device.close()
     except Exception as e:
-        module.fail_json(msg="cannot close device connection: " + str(e))
+        pass
 
     new_facts = {}
     # Prepend all facts with napalm_ for unique namespace

--- a/napalm_ansible/napalm_install_config.py
+++ b/napalm_ansible/napalm_install_config.py
@@ -313,7 +313,7 @@ def main():
     try:
         device.close()
     except Exception as e:
-        module.fail_json(msg="cannot close device connection: " + str(e))
+        pass
 
     module.exit_json(changed=changed, msg=diff)
 

--- a/napalm_ansible/napalm_ping.py
+++ b/napalm_ansible/napalm_ping.py
@@ -233,7 +233,7 @@ def main():
     try:
         device.close()
     except Exception as e:
-        module.fail_json(msg="cannot close device connection: " + str(e))
+        pass
 
     module.exit_json(changed=False, results=ping_response)
 

--- a/napalm_ansible/napalm_validate.py
+++ b/napalm_ansible/napalm_validate.py
@@ -251,8 +251,7 @@ def main():
         try:
             device.close()
         except Exception as err:
-            module.fail_json(
-                msg="cannot close device connection: {0}".format(str(err)))
+            pass
 
     results = {}
     results['compliance_report'] = compliance_report

--- a/napalm_ansible/napalm_validate.py
+++ b/napalm_ansible/napalm_validate.py
@@ -250,7 +250,7 @@ def main():
         # close device connection
         try:
             device.close()
-        except Exception as err:
+        except Exception:
             pass
 
     results = {}


### PR DESCRIPTION
Verified this change fixes a problem where playbooks that use SSH proxies fail (ProxyCommand directives in ~/.ssh/config)