### PR TITLE
Release napalm-ansible 0.8.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,9 @@
 develop
 =====
+
+
+0.8.0
+=====
     
     - Fix import so that reunified napalm gets tried first
     - Fix except statements to that they are compatible with Python3

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ reqs = [str(ir.req) for ir in install_reqs]
 
 setup(
     name="napalm-ansible",
-    version='0.7.2',
+    version='0.8.0',
     packages=["napalm_ansible"],
     author="David Barroso, Kirk Byers, Mircea Ulinic",
     author_email="dbarrosop@dravetech.com, ktbyers@twb-tech.com",


### PR DESCRIPTION
Get napalm-ansible to work with reunified napalm.