### PR TITLE
Fix Travis reference to napalm-base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
 install:
     - pip install pylama
-    - pip install napalm-base
+    - pip install napalm
     - pip install "ansible>=$ANSIBLE_VERSION.0,<$ANSIBLE_VERSION.99"
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Operating System :: MacOS',
     ],
-    url="https://github.com/napalm-automation/napalm-base",
+    url="https://github.com/napalm-automation/napalm-ansible",
     include_package_data=True,
     install_requires=reqs,
     entry_points={


### PR DESCRIPTION
Needs to occur after napalm pip installer issue is fixed on PYPI.