### PR TITLE
Don't fail on undefined optional module parameters

### DIFF
--- a/napalm_ansible/napalm_cli.py
+++ b/napalm_ansible/napalm_cli.py
@@ -141,8 +141,7 @@ def main():
     timeout = module.params['timeout']
     args = module.params['args']
 
-    argument_check = {'hostname': hostname, 'username': username,
-                      'dev_os': dev_os, 'password': password}
+    argument_check = {'hostname': hostname, 'username': username, 'dev_os': dev_os}
     for key, val in argument_check.items():
         if val is None:
             module.fail_json(msg=str(key) + " is required")

--- a/napalm_ansible/napalm_get_facts.py
+++ b/napalm_ansible/napalm_get_facts.py
@@ -205,8 +205,7 @@ def main():
     ignore_notimplemented = module.params['ignore_notimplemented']
     implementation_errors = []
 
-    argument_check = {'hostname': hostname, 'username': username,
-                      'dev_os': dev_os, 'password': password}
+    argument_check = {'hostname': hostname, 'username': username, 'dev_os': dev_os}
     for key, val in argument_check.items():
         if val is None:
             module.fail_json(msg=str(key) + " is required")

--- a/napalm_ansible/napalm_install_config.py
+++ b/napalm_ansible/napalm_install_config.py
@@ -232,8 +232,7 @@ def main():
     get_diffs = module.params['get_diffs']
     archive_file = module.params['archive_file']
 
-    argument_check = {'hostname': hostname, 'username': username,
-                      'dev_os': dev_os, 'password': password}
+    argument_check = {'hostname': hostname, 'username': username, 'dev_os': dev_os}
     for key, val in argument_check.items():
         if val is None:
             module.fail_json(msg=str(key) + " is required")

--- a/napalm_ansible/napalm_parse_yang.py
+++ b/napalm_ansible/napalm_parse_yang.py
@@ -222,8 +222,7 @@ def parse_from_device(module, os_choices):
     profiles = module.params['profiles']
 
     dev_os = module.params['dev_os']
-    argument_check = {'hostname': hostname, 'username': username,
-                      'dev_os': dev_os, 'password': password}
+    argument_check = {'hostname': hostname, 'username': username, 'dev_os': dev_os}
     for key, val in argument_check.items():
         if val is None:
             module.fail_json(msg=str(key) + " is required")

--- a/napalm_ansible/napalm_ping.py
+++ b/napalm_ansible/napalm_ping.py
@@ -203,8 +203,7 @@ def main():
         ping_optional_args['timeout'] = ping_optional_args['ping_timeout']
         ping_optional_args.pop('ping_timeout')
 
-    argument_check = {'hostname': hostname, 'username': username,
-                      'dev_os': dev_os, 'password': password}
+    argument_check = {'hostname': hostname, 'username': username, 'dev_os': dev_os}
     for key, val in argument_check.items():
         if val is None:
             module.fail_json(msg=str(key) + " is required")

--- a/napalm_ansible/napalm_validate.py
+++ b/napalm_ansible/napalm_validate.py
@@ -165,8 +165,7 @@ def get_device_instance(module, os_choices):
     password = module.params['password']
     timeout = module.params['timeout']
 
-    argument_check = {'hostname': hostname, 'username': username,
-                      'dev_os': dev_os, 'password': password}
+    argument_check = {'hostname': hostname, 'username': username, 'dev_os': dev_os}
     for key, val in argument_check.items():
         if val is None:
             module.fail_json(msg=str(key) + " is required")


### PR DESCRIPTION
According to documentation, `password` module parameter is optional.
There are valid reasons for that, such as logging with a password-less scheme, e.g. using an ssh key or an ssh agent.

So, remove `password` from the arguments check, as it can be None. 