### PR TITLE
save the candidate configuration before we rollback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 develop
 =====
 
+    - Add support for saving `candidate_file` during the config install
+
 0.9.0
 =====
 

--- a/napalm_ansible/modules/napalm_install_config.py
+++ b/napalm_ansible/modules/napalm_install_config.py
@@ -193,7 +193,8 @@ def main():
             replace_config=dict(type='bool', required=False, default=False),
             diff_file=dict(type='str', required=False, default=None),
             get_diffs=dict(type='bool', required=False, default=True),
-            archive_file=dict(type='str', required=False, default=None)
+            archive_file=dict(type='str', required=False, default=None),
+            candidate_file=dict(type='str', required=False, default=None)
         ),
         supports_check_mode=True
     )
@@ -231,6 +232,7 @@ def main():
     diff_file = module.params['diff_file']
     get_diffs = module.params['get_diffs']
     archive_file = module.params['archive_file']
+    candidate_file = module.params['candidate_file']
 
     argument_check = {'hostname': hostname, 'username': username, 'dev_os': dev_os}
     for key, val in argument_check.items():
@@ -290,6 +292,13 @@ def main():
             save_to_file(diff, diff_file)
     except Exception as e:
         module.fail_json(msg="cannot diff config: " + str(e))
+
+    try:
+        if candidate_file is not None:
+            running_config = device.get_config(retrieve="candidate")["candidate"]
+            save_to_file(running_config, candidate_file)
+    except Exception, e:
+        module.fail_json(msg="cannot retrieve running config:" + str(e))
 
     try:
         if module.check_mode or not commit_changes:

--- a/napalm_ansible/modules/napalm_install_config.py
+++ b/napalm_ansible/modules/napalm_install_config.py
@@ -109,6 +109,13 @@ options:
               retrieved if not set.
         default: None
         required: False
+    candidate_file:
+        description:
+            - File to store backup of candidate config from device. This is the
+              config we are intending to install, before we roll back to the
+              running_config.
+        default: None
+        required: False
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
In case you want to save a copy of the candidate config without trusting the `get_diffs()` implementation from your vendor.

For example: JunOS delivers a not-really-diff of their CLI config. This isn't something you can pipe to `patch(1)`.
Also, there are some EOS bugs with `show session diffs` which spam erroneous config when there is really no diff in reality (Arista bug 244870)

This is the same as `archive_file` except we pull the candidate config _just_ before we rollback our changes we just pushed.

Use it just like `archive_file` in your ansible task.
