### PR TITLE
handle saving bytes like object in merge operation (saving diffs to file)

### DIFF
--- a/napalm_ansible/modules/napalm_install_config.py
+++ b/napalm_ansible/modules/napalm_install_config.py
@@ -270,6 +270,8 @@ def main():
         if archive_file is not None:
             running_config = device.get_config(retrieve="running")["running"]
             save_to_file(running_config, archive_file)
+    except TypeError:
+            save_to_file(str(running_config, 'utf-8'), archive_file)
     except Exception as e:
         module.fail_json(msg="cannot retrieve running config:" + str(e))
 
@@ -297,6 +299,8 @@ def main():
             diff = None
         if diff_file is not None and get_diffs:
             save_to_file(diff, diff_file)
+    except TypeError:
+            save_to_file(str(diff, 'utf-8'), diff_file)
     except Exception as e:
         module.fail_json(msg="cannot diff config: " + str(e))
 
@@ -304,6 +308,8 @@ def main():
         if candidate_file is not None:
             running_config = device.get_config(retrieve="candidate")["candidate"]
             save_to_file(running_config, candidate_file)
+    except TypeError:
+            save_to_file(str(running_config, 'utf-8'), candidate_file)
     except Exception as e:
         module.fail_json(msg="cannot retrieve running config:" + str(e))
 


### PR DESCRIPTION
I ran into an issue where writing the diffs from a merge operation was failing (TypeError: write() argument must be str, not bytes). I'm unsure the cause (aside from obviously getting a bytes-like object as opposed to a string) and didn't really investigate too much yet. I forked this so I could make a quick and dirty fix for myself but figured I should make a PR to make sure folks are aware of this if they weren't already.

Some info:
Working against a Cisco CSR1000v (ios-xe) running 16.0.8.01a
Ansible 2.5.2
Python 3.6.3

I'm not sure that this is the "right" fix, but it is working in limited testing just fine so far. I will try to update this this weekend with some information (Ansible output/logs/etc.).

Carl