### PR TITLE
Eliminated the os_choices option for better support of community drivers

### DIFF
--- a/napalm_ansible/modules/napalm_cli.py
+++ b/napalm_ansible/modules/napalm_cli.py
@@ -4,11 +4,11 @@ from ansible.module_utils.basic import AnsibleModule, return_values
 DOCUMENTATION = '''
 ---
 module: napalm_cli
-author: "Charlie Allom - based on napalm_ping Jason Edelman (@jedelman8)"
+author: "Charlie Allom"
 version_added: "2.2"
-short_description: "Executes CLI commands and returns response using NAPALM"
+short_description: "Executes network device CLI commands and returns response using NAPALM"
 description:
-    - "This module logs into the device, issues a ping request, and returns the response"
+    - "Executes network device CLI commands and returns response using NAPALM"
 requirements:
     - napalm
 options:
@@ -32,8 +32,6 @@ options:
         description:
           - OS of the device
         required: False
-        choices: ['eos', 'junos', 'iosxr', 'fortios', 'ios', 'mock', 'nxos', 'nxos_ssh', 'panos',
-        'vyos']
     provider:
         description:
           - Dictionary which acts as a collection of arguments used to define the characteristics
@@ -97,8 +95,6 @@ if not napalm_found:
 
 
 def main():
-    os_choices = ['eos', 'junos', 'iosxr', 'fortios',
-                  'ios', 'mock', 'nxos', 'nxos_ssh', 'panos', 'vyos', 'ros']
     module = AnsibleModule(
         argument_spec=dict(
             hostname=dict(type='str', required=False, aliases=['host']),
@@ -106,7 +102,7 @@ def main():
             password=dict(type='str', required=False, no_log=True),
             provider=dict(type='dict', required=False),
             timeout=dict(type='int', required=False, default=60),
-            dev_os=dict(type='str', required=False, choices=os_choices),
+            dev_os=dict(type='str', required=False),
             optional_args=dict(required=False, type='dict', default=None),
             args=dict(required=True, type='dict', default=None),
         ),
@@ -145,10 +141,6 @@ def main():
     for key, val in argument_check.items():
         if val is None:
             module.fail_json(msg=str(key) + " is required")
-
-    # use checks outside of ansible defined checks, since params come can come from provider
-    if dev_os not in os_choices:
-        module.fail_json(msg="dev_os is not set to " + str(os_choices))
 
     if module.params['optional_args'] is None:
         optional_args = {}

--- a/napalm_ansible/modules/napalm_get_facts.py
+++ b/napalm_ansible/modules/napalm_get_facts.py
@@ -46,8 +46,6 @@ options:
         description:
           - OS of the device
         required: False
-        choices: ['eos', 'junos', 'iosxr', 'fortios', 'ios', 'mock', 'nxos', 'nxos_ssh', 'panos',
-        'vyos']
     provider:
         description:
           - Dictionary which acts as a collection of arguments used to define the characteristics
@@ -155,15 +153,13 @@ if not napalm_found:
 
 
 def main():
-    os_choices = ['eos', 'junos', 'iosxr', 'fortios', 'ios', 'mock', 'nxos', 'nxos_ssh', 'panos',
-                  'vyos', 'ros']
     module = AnsibleModule(
         argument_spec=dict(
             hostname=dict(type='str', required=False, aliases=['host']),
             username=dict(type='str', required=False),
             password=dict(type='str', required=False, no_log=True),
             provider=dict(type='dict', required=False),
-            dev_os=dict(type='str', required=False, choices=os_choices),
+            dev_os=dict(type='str', required=False),
             timeout=dict(type='int', required=False, default=60),
             ignore_notimplemented=dict(type='bool', required=False, default=False),
             args=dict(type='dict', required=False, default=None),
@@ -209,10 +205,6 @@ def main():
     for key, val in argument_check.items():
         if val is None:
             module.fail_json(msg=str(key) + " is required")
-
-    # use checks outside of ansible defined checks, since params come can come from provider
-    if dev_os not in os_choices:
-        module.fail_json(msg="dev_os is not set to " + str(os_choices))
 
     if module.params['optional_args'] is None:
         optional_args = {}

--- a/napalm_ansible/modules/napalm_install_config.py
+++ b/napalm_ansible/modules/napalm_install_config.py
@@ -56,8 +56,6 @@ options:
         description:
           - OS of the device
         required: False
-        choices: ['eos', 'junos', 'iosxr', 'fortios', 'ios', 'mock', 'nxos', 'nxos_ssh', 'panos',
-        'vyos']
     timeout:
         description:
           - Time in seconds to wait for the device to respond
@@ -183,8 +181,6 @@ def save_to_file(content, filename):
 
 
 def main():
-    os_choices = ['eos', 'junos', 'iosxr', 'fortios', 'ios', 'mock', 'nxos',
-                  'nxos_ssh', 'panos', 'vyos', 'ros']
     module = AnsibleModule(
         argument_spec=dict(
             hostname=dict(type='str', required=False, aliases=['host']),
@@ -195,7 +191,7 @@ def main():
             optional_args=dict(required=False, type='dict', default=None),
             config_file=dict(type='str', required=False),
             config=dict(type='str', required=False),
-            dev_os=dict(type='str', required=False, choices=os_choices),
+            dev_os=dict(type='str', required=False),
             commit_changes=dict(type='bool', required=True),
             replace_config=dict(type='bool', required=False, default=False),
             diff_file=dict(type='str', required=False, default=None),
@@ -245,10 +241,6 @@ def main():
     for key, val in argument_check.items():
         if val is None:
             module.fail_json(msg=str(key) + " is required")
-
-    # use checks outside of ansible defined checks, since params come can come from provider
-    if dev_os not in os_choices:
-        module.fail_json(msg="dev_os is not set to " + str(os_choices))
 
     if module.params['optional_args'] is None:
         optional_args = {}

--- a/napalm_ansible/modules/napalm_parse_yang.py
+++ b/napalm_ansible/modules/napalm_parse_yang.py
@@ -70,8 +70,6 @@ options:
         description:
           - OS of the device
         required: False
-        choices: ['eos', 'junos', 'iosxr', 'fortios', 'ios', 'mock',
-                  'nxos', 'nxos_ssh', 'panos', 'vyos']
     provider:
         description:
           - Dictionary which acts as a collection of arguments used to define
@@ -210,7 +208,7 @@ def parse_from_file(module):
     return root
 
 
-def parse_from_device(module, os_choices):
+def parse_from_device(module):
     update_module_provider_data(module)
 
     hostname = module.params['hostname']
@@ -226,12 +224,6 @@ def parse_from_device(module, os_choices):
     for key, val in argument_check.items():
         if val is None:
             module.fail_json(msg=str(key) + " is required")
-
-    # use checks outside of ansible defined checks, since params come can come
-    # from provider
-    dev_os = module.params['dev_os']
-    if dev_os not in os_choices:
-        module.fail_json(msg="dev_os is not set to " + str(os_choices))
 
     if module.params['optional_args'] is None:
         optional_args = {}
@@ -267,8 +259,6 @@ def parse_from_device(module, os_choices):
 
 
 def main():
-    os_choices = ['eos', 'junos', 'iosxr', 'fortios', 'ios',
-                  'mock', 'nxos', 'nxos_ssh', 'panos', 'vyos']
     module = AnsibleModule(
         argument_spec=dict(
             hostname=dict(type='str', required=False, aliases=['host']),
@@ -280,7 +270,7 @@ def main():
                       choices=["config", "state", "both"]),
             models=dict(type="list", required=True),
             profiles=dict(type="list", required=False),
-            dev_os=dict(type='str', required=False, choices=os_choices),
+            dev_os=dict(type='str', required=False),
             timeout=dict(type='int', required=False, default=60),
             optional_args=dict(type='dict', required=False, default=None),
 
@@ -296,7 +286,7 @@ def main():
     if module.params["file_path"]:
         yang_model = parse_from_file(module)
     else:
-        yang_model = parse_from_device(module, os_choices)
+        yang_model = parse_from_device(module)
 
     module.exit_json(yang_model=yang_model.to_dict(filter=True))
 

--- a/napalm_ansible/modules/napalm_ping.py
+++ b/napalm_ansible/modules/napalm_ping.py
@@ -51,7 +51,6 @@ options:
         description:
           - OS of the device
         required: False
-        choices: ['eos', 'junos', 'ios', 'vyos', 'ros']
     timeout:
         description:
           - Time in seconds to wait for the device to respond
@@ -145,7 +144,6 @@ if not napalm_found:
 
 
 def main():
-    os_choices = ['eos', 'junos', 'ios', 'vyos', 'ros']
     module = AnsibleModule(
         argument_spec=dict(
             hostname=dict(type='str', required=False, aliases=['host']),
@@ -154,7 +152,7 @@ def main():
             provider=dict(type='dict', required=False),
             timeout=dict(type='int', required=False, default=60),
             optional_args=dict(required=False, type='dict', default=None),
-            dev_os=dict(type='str', required=False, choices=os_choices),
+            dev_os=dict(type='str', required=False),
             destination=dict(type='str', required=True),
             source=dict(type='str', required=False),
             ttl=dict(type='str', required=False),
@@ -207,10 +205,6 @@ def main():
     for key, val in argument_check.items():
         if val is None:
             module.fail_json(msg=str(key) + " is required")
-
-    # use checks outside of ansible defined checks, since params come can come from provider
-    if dev_os not in os_choices:
-        module.fail_json(msg="dev_os is not set to " + str(os_choices))
 
     if module.params['optional_args'] is None:
         optional_args = {}

--- a/napalm_ansible/modules/napalm_validate.py
+++ b/napalm_ansible/modules/napalm_validate.py
@@ -47,8 +47,6 @@ options:
         description:
           - OS of the device.
         required: False
-        choices: ['eos', 'junos', 'iosxr', 'fortios', 'ios', 'mock',
-                  'nxos', 'nxos_ssh', 'panos', 'vyos']
     provider:
         description:
           - Dictionary which acts as a collection of arguments used to define
@@ -138,7 +136,7 @@ def get_compliance_report(module, device):
     return device.compliance_report(module.params['validation_file'])
 
 
-def get_device_instance(module, os_choices):
+def get_device_instance(module):
 
     provider = module.params['provider'] or {}
 
@@ -170,11 +168,6 @@ def get_device_instance(module, os_choices):
         if val is None:
             module.fail_json(msg=str(key) + " is required")
 
-    # use checks outside of ansible defined checks,
-    # since params come can come from provider
-    if dev_os not in os_choices:
-        module.fail_json(msg="dev_os is not set to " + str(os_choices))
-
     optional_args = module.params['optional_args'] or {}
     try:
         network_driver = get_network_driver(dev_os)
@@ -205,8 +198,6 @@ def get_root_object(models):
 
 
 def main():
-    os_choices = ['eos', 'junos', 'iosxr', 'fortios',
-                  'ios', 'mock', 'nxos', 'nxos_ssh', 'panos', 'vyos']
     module = AnsibleModule(
         argument_spec=dict(
             models=dict(type="list", required=False),
@@ -215,7 +206,7 @@ def main():
             username=dict(type='str', required=False),
             password=dict(type='str', required=False, no_log=True),
             provider=dict(type='dict', required=False),
-            dev_os=dict(type='str', required=False, choices=os_choices),
+            dev_os=dict(type='str', required=False),
             timeout=dict(type='int', required=False, default=60),
             optional_args=dict(type='dict', required=False, default=None),
             validation_file=dict(type='str', required=True),
@@ -236,7 +227,7 @@ def main():
 
         device.load_dict(module.params["data"])
     else:
-        device = get_device_instance(module, os_choices)
+        device = get_device_instance(module)
     compliance_report = get_compliance_report(module, device)
 
     if not module.params["models"]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [pylama]
 linters = mccabe,pep8,pyflakes
 ignore = D203,C901
-skip = .tox/*
+skip = .tox/*,build/*
 
 [pylama:pep8]
 max_line_length = 100


### PR DESCRIPTION
os_choices causes issues as it unnecessarily limits the driver options and requires us to roll the napalm-ansible library just to maintain this list.