### PR TITLE
Fix error with 'write() argument must be str, not bytes'

### DIFF
--- a/napalm_ansible/modules/napalm_install_config.py
+++ b/napalm_ansible/modules/napalm_install_config.py
@@ -177,7 +177,10 @@ if not napalm_found:
 def save_to_file(content, filename):
     f = open(filename, 'w')
     try:
-        f.write(content)
+        if type(content) is bytes:
+            f.write(content.decode())
+        else:
+            f.write(content)
     finally:
         f.close()
 


### PR DESCRIPTION
fix the error on python3. works on both python2 and python3