### PR TITLE
PY3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ language: python
 
 python:
     - 2.7
+    - 3.5
+    - 3.6
 
 env:
-    - ANSIBLE_VERSION=2.2
     - ANSIBLE_VERSION=2.3
     - ANSIBLE_VERSION=2.4
     - ANSIBLE_VERSION=2.5
+    - ANSIBLE_VERSION=2.6
 
 install:
     - pip install pylama

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 develop
 =====
 
+    - Add Python3 support
     - Add support for saving `candidate_file` during the config install
     - Fix issue with an exception in napalm_install_config
 

--- a/napalm_ansible/__init__.py
+++ b/napalm_ansible/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals, print_function
 import os
 import ansible
 from distutils.version import LooseVersion

--- a/napalm_ansible/modules/napalm_cli.py
+++ b/napalm_ansible/modules/napalm_cli.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals, print_function
 from ansible.module_utils.basic import AnsibleModule, return_values
 
 

--- a/napalm_ansible/modules/napalm_diff_yang.py
+++ b/napalm_ansible/modules/napalm_diff_yang.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-
 """
 (c) 2017 David Barroso <dbarrosop@dravetech.com>
 
@@ -19,6 +18,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 """
+from __future__ import unicode_literals, print_function
 from ansible.module_utils.basic import AnsibleModule
 
 try:

--- a/napalm_ansible/modules/napalm_get_facts.py
+++ b/napalm_ansible/modules/napalm_get_facts.py
@@ -16,6 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 """
+from __future__ import unicode_literals, print_function
 from ansible.module_utils.basic import AnsibleModule, return_values
 
 

--- a/napalm_ansible/modules/napalm_install_config.py
+++ b/napalm_ansible/modules/napalm_install_config.py
@@ -17,6 +17,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 """
+from __future__ import unicode_literals, print_function
 from ansible.module_utils.basic import AnsibleModule, return_values
 
 
@@ -175,11 +176,8 @@ if not napalm_found:
 
 
 def save_to_file(content, filename):
-    f = open(filename, 'w')
-    try:
+    with open(filename, 'w') as f:
         f.write(content)
-    finally:
-        f.close()
 
 
 def main():
@@ -288,7 +286,7 @@ def main():
 
     try:
         if get_diffs:
-            diff = device.compare_config().encode('utf-8')
+            diff = device.compare_config()
             changed = len(diff) > 0
         else:
             changed = True

--- a/napalm_ansible/modules/napalm_parse_yang.py
+++ b/napalm_ansible/modules/napalm_parse_yang.py
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 """
-# standard ansible module imports
+from __future__ import unicode_literals, print_function
 from ansible.module_utils.basic import AnsibleModule, return_values
 import json
 

--- a/napalm_ansible/modules/napalm_ping.py
+++ b/napalm_ansible/modules/napalm_ping.py
@@ -1,5 +1,3 @@
-from ansible.module_utils.basic import AnsibleModule, return_values
-
 """
 (c) 2017 Jason Edelman <jason@networktocode.com>
 
@@ -15,6 +13,9 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 """
+from __future__ import unicode_literals, print_function
+from ansible.module_utils.basic import AnsibleModule, return_values
+
 
 DOCUMENTATION = '''
 ---

--- a/napalm_ansible/modules/napalm_translate_yang.py
+++ b/napalm_ansible/modules/napalm_translate_yang.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-
 """
 (c) 2017 David Barroso <dbarrosop@dravetech.com>
 
@@ -19,7 +18,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 """
-# standard ansible module imports
+from __future__ import unicode_literals, print_function
 from ansible.module_utils.basic import AnsibleModule
 
 try:

--- a/napalm_ansible/modules/napalm_validate.py
+++ b/napalm_ansible/modules/napalm_validate.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals, print_function
 from ansible.module_utils.basic import AnsibleModule, return_values
 
 napalm_found = False

--- a/napalm_ansible/plugins/action/napalm.py
+++ b/napalm_ansible/plugins/action/napalm.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function, unicode_literals
 __metaclass__ = type
 
 from ansible.plugins.action.normal import ActionModule as _ActionModule

--- a/tests/napalm_get_facts/get_facts_error.yaml
+++ b/tests/napalm_get_facts/get_facts_error.yaml
@@ -7,7 +7,6 @@
     - block:
         - name: get facts from device
           napalm_get_facts:                   # NAPALM plugin
-            provider: {}
             hostname: "{{ host }}"            # start of connection parameters
             username: "{{ user }}"
             dev_os: "{{ os }}"

--- a/tests/napalm_get_facts/get_facts_error.yaml
+++ b/tests/napalm_get_facts/get_facts_error.yaml
@@ -7,6 +7,7 @@
     - block:
         - name: get facts from device
           napalm_get_facts:                   # NAPALM plugin
+            provider: {}
             hostname: "{{ host }}"            # start of connection parameters
             username: "{{ user }}"
             dev_os: "{{ os }}"
@@ -29,4 +30,5 @@
                 var: ansible_failed_result.msg
         - assert:
             that:
-                - "{{ ansible_failed_result.msg == \"[interfaces] cannot retrieve device data: u'Key blah is not present'\" }}"
+                - "{{ '[interfaces] cannot retrieve device data' in ansible_failed_result.msg }}"
+                - "{{ 'Key blah is not present' in ansible_failed_result.msg }}"


### PR DESCRIPTION
Add Python3 support to napalm-ansible
Remove testing of Ansible 2.2 (EOL by Ansible).