### PR TITLE
ansible_network_os

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 develop
 =====
 
+    - Add support for ansible_network_os
+
 0.10.0
 =====
 

--- a/napalm_ansible/plugins/action/napalm.py
+++ b/napalm_ansible/plugins/action/napalm.py
@@ -18,6 +18,9 @@ class ActionModule(_ActionModule):
             # Timeout can't be passed via command-line as Ansible defaults to a 10 second timeout
             provider['timeout'] = provider.get('timeout', 60)
 
+            if hasattr(pc, 'network_os'):
+                provider['dev_os'] = provider.get('dev_os', pc.network_os)
+
             self._task.args['provider'] = provider
 
         result = super(ActionModule, self).run(tmp, task_vars)

--- a/tests/napalm_connection/connection_ansible_network_os.yaml
+++ b/tests/napalm_connection/connection_ansible_network_os.yaml
@@ -1,0 +1,13 @@
+---
+- name: Get facts
+  hosts: all
+  connection: local                       # code is run locally
+  gather_facts: no                        # don't gather facts
+  tasks:
+    - block:
+      - name: get facts from device
+        napalm_get_facts:                   # NAPALM plugin
+          optional_args:
+            path: "{{ playbook_dir }}/mocked"
+            profile: "{{ profile }}"
+          filter: ['facts']

--- a/tests/napalm_connection/hosts
+++ b/tests/napalm_connection/hosts
@@ -1,5 +1,5 @@
 [all]
-dummy              os=mock   profile=[eos] password=vagrant
+dummy              os=mock   profile=[eos] password=vagrant ansible_network_os=mock
 
 [all:vars]
 ansible_python_interpreter="/usr/bin/env python"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -4,6 +4,7 @@ set -e
 ansible-playbook -i napalm_connection/hosts napalm_connection/connection_info_missing.yaml
 ansible-playbook -i napalm_connection/hosts napalm_connection/connection_info_in_vars.yaml
 ansible-playbook -i napalm_connection/hosts napalm_connection/connection_info_in_args.yaml -u vagrant
+ansible-playbook -i napalm_connection/hosts napalm_connection/connection_ansible_network_os.yaml -u vagrant
 ANSIBLE_REMOTE_USER=vagrant ansible-playbook -i napalm_connection/hosts napalm_connection/connection_info_in_env.yaml 
 
 ansible-playbook -i napalm_install_config/hosts -l "*.dry_run.*" napalm_install_config/config.yaml -C


### PR DESCRIPTION
This PR enable the possibility to use ansible_network_os as a default source of dev_os.
Fixes #128