### PR TITLE
Expand filenames for *_file parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ develop
 
     - Add support for ansible_network_os
     - Fix spelling for parameters in README.md
+    - Expand filenames for `*_file` parameters
 
 0.10.0
 =====

--- a/napalm_ansible/modules/napalm_install_config.py
+++ b/napalm_ansible/modules/napalm_install_config.py
@@ -18,6 +18,7 @@ You should have received a copy of the GNU General Public License
 along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 """
 from __future__ import unicode_literals, print_function
+import os.path
 from ansible.module_utils.basic import AnsibleModule, return_values
 
 
@@ -236,6 +237,14 @@ def main():
     get_diffs = module.params['get_diffs']
     archive_file = module.params['archive_file']
     candidate_file = module.params['candidate_file']
+    if config_file:
+        config_file = os.path.expanduser(os.path.expandvars(config_file))
+    if diff_file:
+        diff_file = os.path.expanduser(os.path.expandvars(diff_file))
+    if archive_file:
+        archive_file = os.path.expanduser(os.path.expandvars(archive_file))
+    if candidate_file:
+        candidate_file = os.path.expanduser(os.path.expandvars(candidate_file))
 
     argument_check = {'hostname': hostname, 'username': username, 'dev_os': dev_os}
     for key, val in argument_check.items():


### PR DESCRIPTION
In Ansible, most filenames are passed through expanduser/expandvars.
This way, a user can use something like `~/batman/{{ host }}.conf`. Do
the same in napalm-ansible.