### PR TITLE
Provide diff as `result.diff` instead of `result.msg`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-develop
+1.1.0
 =====
     - Fix issue with -u <username> not working.
     - Update tests to use newer Python and to use Ansible 2.8.x or 2.9.x.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+develop
+=======
+    - Provide diff in napalm_install_config in ``result.diff`` instead
+      of ``result.msg``.
+
 1.1.0
 =====
     - Fix issue with -u <username> not working.

--- a/napalm_ansible/modules/napalm_install_config.py
+++ b/napalm_ansible/modules/napalm_install_config.py
@@ -157,11 +157,13 @@ changed:
     returned: always
     type: bool
     sample: True
-msg:
+diff:
     description: diff of the change
     returned: always
-    type: string
-    sample: "[edit system]\n-  host-name lab-testing;\n+  host-name lab;"
+    type: dict
+    sample: {
+        'prepared': "[edit system]\n-  host-name lab-testing;\n+  host-name lab;",
+    }
 """
 
 napalm_found = False
@@ -331,7 +333,7 @@ def main():
     except Exception as e:
         module.fail_json(msg="cannot close device connection: " + str(e))
 
-    module.exit_json(changed=changed, msg=diff)
+    module.exit_json(changed=changed, diff={"prepared": diff})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This way, the diff can be automatically displayed when using `--diff`
and the module behaves more like other Ansible modules. Most of the
credit for this goes to @fabrepe.

Fix #180

I have documented the change hoping we don't need to continue to put the diff in `msg` as well (since it would be displayed twice with `-v`). However, if you feel strongly about this, we could keep it as an undocumented result attribute.