### PR TITLE
Bugfix/184

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
     - ANSIBLE_VERSION=2.9
 
 install:
-    - pip install -r requirements-dev.txt
     - pip install "ansible>=$ANSIBLE_VERSION.0,<$ANSIBLE_VERSION.99"
+    - pip install -r requirements-dev.txt
     - pip install -e .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 env:
     - ANSIBLE_VERSION=2.8
     - ANSIBLE_VERSION=2.9
+    - ANSIBLE_VERSION=2.10
 
 install:
     - pip install "ansible>=$ANSIBLE_VERSION.0,<$ANSIBLE_VERSION.99"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-    - 2.7
     - 3.6
     - 3.7
     - 3.8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,12 @@ develop
 =======
     - Provide diff in napalm_install_config in ``result.diff`` instead
       of ``result.msg``.
+    - Drop support of Python 2.7
+    - Update tests to iuse Ansible 2.10.x.
 
 1.1.0
 =====
-    - Fix issue with -u <username> not working.
+    - FIX ISSUE WITH -U <USERNAME> NOT WORKING.
     - Update tests to use newer Python and to use Ansible 2.8.x or 2.9.x.
     - Improving documentation.
     - Update module docstring.

--- a/tests/napalm_get_facts/get_facts_not_implemented.yaml
+++ b/tests/napalm_get_facts/get_facts_not_implemented.yaml
@@ -28,7 +28,7 @@
       rescue:
         - fail:
               msg: Whe shouldn't be here
-          when: ignore_notimplemented
+          when: ignore_notimplemented|bool
         - assert:
             that:
                 - ansible_failed_result.msg == "The filter route_to is not supported in napalm-mock [get_route_to()]"


### PR DESCRIPTION
Hello,

Ansible release 2.10 borke the build pipeline several ways.
- this version changed the default of `CONDITIONAL_BARE_VARS`, which broke the test get_facts_not_implemented.yaml with ignore_notimplemented=false.
- The installation of the ansible python package was done twice in the .travis file. One in the requirements, the other from the ENV variable. The second was not correctly cleaning the _newer_ package files, resulting in a python error on ansible-playbook invocation.

While I was editing the .travis.yml file, I also removed the test against python 2.7 as `napalm` does not support this version any longer.