### PR TITLE
Support retrieving `dev_os` from FQCN format for network_os

### DIFF
--- a/collection/plugins/action/napalm.py
+++ b/collection/plugins/action/napalm.py
@@ -27,6 +27,8 @@ class ActionModule(_ActionModule):
 
             if hasattr(pc, "network_os"):
                 provider["dev_os"] = provider.get("dev_os", pc.network_os)
+                if (provider["dev_os"]).find('.') > 1:
+                    provider["dev_os"] = ((provider["dev_os"]).split('.')).pop()
 
             self._task.args["provider"] = provider
 

--- a/napalm_ansible/plugins/action/napalm.py
+++ b/napalm_ansible/plugins/action/napalm.py
@@ -27,7 +27,9 @@ class ActionModule(_ActionModule):
 
             if hasattr(pc, "network_os"):
                 provider["dev_os"] = provider.get("dev_os", pc.network_os)
-
+                if (provider["dev_os"]).find('.') > 1:
+                    provider["dev_os"] = ((provider["dev_os"]).split('.')).pop()
+            
             self._task.args["provider"] = provider
 
         result = super(ActionModule, self).run(tmp, task_vars)


### PR DESCRIPTION
If provider["dev_os"] is in FQCN format, strips prefixes

https://github.com/napalm-automation/napalm-ansible/issues/196