### PR TITLE
Fix error on empty pc.network_os

### DIFF
--- a/napalm_ansible/plugins/action/napalm.py
+++ b/napalm_ansible/plugins/action/napalm.py
@@ -25,7 +25,7 @@ class ActionModule(_ActionModule):
             # Timeout can't be passed via command-line as Ansible defaults to a 10 second timeout
             provider["timeout"] = provider.get("timeout", 60)
 
-            if hasattr(pc, "network_os"):
+            if getattr(pc, "network_os", None):
                 provider["dev_os"] = provider.get("dev_os", pc.network_os)
                 if (provider["dev_os"]).find('.') > 1:
                     provider["dev_os"] = ((provider["dev_os"]).split('.')).pop()


### PR DESCRIPTION
Right now if network_os is set to None, provider is not set and dev_os is set in a task, this results in the following error:

```ansible
fatal: [host -> execution_host]: FAILED! => {
    "changed": false,
    "msg": "Task failed: 'NoneType' object has no attribute 'find'"
}
```

This is caused by a check `hasattr(pc, "network_os")` which is true even when network_os is None.
This PR fixes that.